### PR TITLE
[RIO] Implementation of Branch Protection Rules for main branch

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,52 @@
+# Branch Protection Implementation
+
+This document provides instructions for implementing the branch protection rules for the `main` branch. These settings must be applied manually in the GitHub UI since they require administrative permissions.
+
+## Branch Protection Settings
+
+### For the `main` branch:
+
+1. Navigate to the repository settings: https://github.com/Digidinc/Mydiv/settings/branches
+2. Click "Add branch protection rule"
+3. Set "Branch name pattern" to `main`
+
+### Configure the following settings:
+
+#### Required settings:
+- [x] Require a pull request before merging
+  - [x] Require approvals: 1
+  - [x] Dismiss stale pull request approvals when new commits are pushed
+  - [ ] Require review from Code Owners (optional for future use)
+
+- [x] Require status checks to pass before merging
+  - [x] Require branches to be up to date before merging
+  - Required status checks:
+    - [x] lint
+    - [x] test
+    - [x] docker
+
+- [x] Require conversation resolution before merging
+
+- [x] Restrict who can push to matching branches
+  - Add repository administrators
+
+#### Recommended settings:
+- [ ] Allow force pushes: Disabled
+- [ ] Allow deletions: Disabled
+
+## Implementation Verification
+
+Once these settings are applied, verify them by:
+
+1. Attempting to push directly to `main` (should fail)
+2. Creating a PR with failing status checks (should prevent merging)
+3. Creating a PR with passing status checks (should allow merging after approval)
+
+## Documentation
+
+This implementation is documented in detail in `coordination/github/BranchProtectionRules.md` for reference by all team members.
+
+---
+
+*These instructions were prepared by: MyDiv RIO*  
+*March 16, 2025 | 04:30 PST*


### PR DESCRIPTION
## Branch Protection Implementation

This PR provides documentation and implementation instructions for branch protection rules on the `main` branch, following the GitHub Flow workflow strategy specified by the AI CEO.

### Implemented Changes

1. Added comprehensive documentation in `coordination/github/BranchProtectionRules.md` detailing:
   - The required protection settings for `main`
   - Branch naming conventions
   - Enforcement policies
   - Troubleshooting guidance

2. Added `.github/BRANCH_PROTECTION.md` with step-by-step instructions for repository administrators to:
   - Configure the branch protection settings
   - Verify the implementation
   - Test the protection rules

### Manual Implementation Required

Branch protection rules require repository administrator permissions and must be implemented manually through the GitHub UI. This PR provides the documentation and instructions needed for that process.

Once this PR is merged, a repository administrator should follow the instructions in `.github/BRANCH_PROTECTION.md` to apply the protection rules.

### Next Steps

After implementing branch protection:
1. Verify that direct pushes to `main` are prevented
2. Confirm that PRs require approvals before merging
3. Validate that status checks (lint, test, docker) are required to pass

This PR completes the second high-priority task from the RIO handoff document, following the GitHub Actions workflow implementation.

2025-03-16 | 04:35 PST  
MyDiv RIO